### PR TITLE
Fix TensorFlow CPU-only package

### DIFF
--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -10,7 +10,7 @@ RUN pip install --upgrade pip
 WORKDIR /app
 
 COPY ./requirements.txt /app
-RUN pip install -r /app/requirements.txt
+RUN pip install -r /app/requirements.gpu.txt
 
 # Hack to get around tensorflow-io issue - https://github.com/tensorflow/io/issues/1755
 RUN pip install tensorflow-io

--- a/requirements.gpu.txt
+++ b/requirements.gpu.txt
@@ -11,7 +11,7 @@ flake8==5.0.4
 kaggle==1.5.12
 pydot==1.4.2
 ipywidgets==8.0.4
-tensorflow-cpu==2.10.1
+tensorflow==2.10.1
 tensorboard==2.10.1
 tensorflow_probability==0.18.0
 flake8-nb==0.5.2


### PR DESCRIPTION
Fixes non-GPU requirements. From TensorFlow pip installing guide (https://www.tensorflow.org/install/pip): For the CPU-only build, use the pip package named tensorflow-cpu.